### PR TITLE
Fix badge image clipping for the individual community pages

### DIFF
--- a/communities/static/css/communities.css
+++ b/communities/static/css/communities.css
@@ -75,7 +75,11 @@
 }
 
 .community-banner {
-	width: 400px;
+	max-width: 400px;
+}
+
+.community-banner>img {
+	display: block;
 }
 
 .community-banner p {

--- a/communities/templates/communities/community.html
+++ b/communities/templates/communities/community.html
@@ -69,7 +69,7 @@
 
 <div id="community-box">
 	<div class="community-banner">
-		<img src="{{ object.badge.url }}" width=400 height=200 alt="">
+		<img src="{{ object.badge.url }}" alt="">
 	</div>
 
 	<div class="box-section has-text-centered">


### PR DESCRIPTION
On the individual community pages, a community's badge `img` clips outside its bounding box in the right sidebar.

This PR fixes that clipping.