### PR TITLE
Fix archive mode config key name

### DIFF
--- a/templates/pages/help/server.html
+++ b/templates/pages/help/server.html
@@ -115,7 +115,7 @@ The following settings can be set here:
  * `privateUserList=false` - if set to true, list of logged in users is not included in session announcements
  * `allowGuests=true` - allow unauthenticated users
  * `allowGuestHosts=true` - if set to false, only authenticated users with the `HOST` flag can create new sessions
- * `archiveMode=false` - when using file backed sessions, rename session file to `oldname.archived` instead of deleting it on termination
+ * `archive=false` - when using file backed sessions, rename session file to `oldname.archived` instead of deleting it on termination
  * `extauth=false` - enable external authentication (you must also set the server URL with  the `--extauth` command line parameter`
  * `extauthkey=key string` - external authentication token validation key
  * `extauthgroup=group name` - external authentication user group (default is no group)


### PR DESCRIPTION
Session archive mode is enabled using the [`archive`  config key](https://github.com/drawpile/Drawpile/blob/340be31995475a037150e01bd15f20510100e6a6/src/libserver/serverconfig.h#L67), yet the dedicated server docs incorrectly state the config key is `archiveMode`. This PR updates the documentation to reflect the correct key name.

I'm a little surprised this hasn't been noticed in the [3 years](https://github.com/drawpile/website/blame/e206bc0bc34f0f5f5fe81fbf873339672d3bfc40/templates/pages/help/server.html#L118) since the documentation has been up. I'm glad our Drawpile server is rather inactive, as we might've otherwise lost a session or two before performing testing to validate archiving was working correctly otherwise.

There's a related issue regarding the [Drawpile server API documentation](https://github.com/drawpile/Drawpile/blob/master/doc/server-api.md#serverwide-settings); I'll open a PR there as well.

Related PR: drawpile/Drawpile#912