### PR TITLE
Add CORS headers to ext-auth endpoint

### DIFF
--- a/drawpile/settings.py
+++ b/drawpile/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'easy_thumbnails',
     'widget_tweaks',
+    'corsheaders',
 
     'dpauth',
     'dpusers',
@@ -41,6 +42,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -157,3 +159,10 @@ LOGGING = {
     },
 }
 
+# CORS Headers
+# Allow requests from any URL.
+CORS_ALLOW_ALL_ORIGINS = True
+# Only allow them for the ext-auth endpoint.
+CORS_URLS_REGEX = r'^/api/ext-auth/?$'
+# And only allow the methods actually required.
+CORS_ALLOW_METHODS = ['OPTIONS', 'POST']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ djangorestframework~=3.12.4
 ed25519==1.5
 confusable-homoglyphs==3.2.0
 requests==2.25.1
+django-cors-headers==3.11.0


### PR DESCRIPTION
Using the django-cors-headers module, which is recommended by the Django REST Framework: <https://www.django-rest-framework.org/topics/ajax-csrf-cors/#cors>. It only allows cross-origin OPTIONS and POST requests to the ext-auth endpoint, nothing more.

These headers are required for browsers to allow AJAX requests to a different page. When doing an AJAX request, the browser first asks via OPTIONS if it's okay to perform it. If the response is successful, it'll actually send the request. In both cases, appropriate Access-Control-* headers need to be set in the response, which the CORS middleware takes care of.

This is required for ext-auth to work in the Drawdance web client, basically.